### PR TITLE
Refine doctors toolbar and refresh authentication UI

### DIFF
--- a/app/src/main/java/com/example/miscitasmedicas/DoctorsActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/DoctorsActivity.kt
@@ -2,6 +2,7 @@ package com.example.miscitasmedicas
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.widget.addTextChangedListener
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
@@ -18,7 +19,7 @@ class DoctorsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_doctors)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
-        toolbar.setNavigationIcon(com.google.android.material.R.drawable.mtrl_ic_arrow_back)
+        toolbar.navigationIcon = AppCompatResources.getDrawable(this, R.drawable.ic_arrow_back)
         toolbar.setNavigationOnClickListener { finish() }
 
         val specialtyName = intent.getStringExtra(EXTRA_SPECIALTY_NAME)

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,11H7.83l4.88,-4.88c0.39,-0.39 0.39,-1.03 0,-1.42 -0.39,-0.39 -1.03,-0.39 -1.42,0l-6.59,6.59c-0.39,0.39 -0.39,1.02 0,1.41l6.59,6.59c0.39,0.39 1.03,0.39 1.42,0 0.39,-0.39 0.39,-1.03 0,-1.42L7.83,13H19c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z" />
+</vector>

--- a/app/src/main/res/layout/activity_doctors.xml
+++ b/app/src/main/res/layout/activity_doctors.xml
@@ -1,37 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/medical_background">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
-        android:layout_width="match_parent" android:layout_height="?attr/actionBarSize"
-        android:title="@string/doctors_title"/>
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="@string/doctors_title"
+        app:titleTextColor="@color/medical_on_primary"/>
 
     <LinearLayout
-        android:layout_width="match_parent" android:layout_height="match_parent"
-        android:orientation="vertical" android:padding="16dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp"
         android:layout_marginTop="?attr/actionBarSize">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tvSpecialtyHeader"
-            android:layout_width="match_parent" android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:text="@string/doctors_title"
-            android:textAppearance="?attr/textAppearanceTitleMedium" />
+            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:textColor="@color/medical_primary" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilSearchDoc"
-            android:layout_width="match_parent" android:layout_height="wrap_content"
-            android:layout_marginTop="8dp">
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:boxBackgroundMode="filled"
+            app:boxBackgroundColor="@color/medical_surface"
+            app:boxStrokeColor="@color/medical_primary"
+            app:hintTextColor="@color/medical_hint">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etSearchDoc"
-                android:layout_width="match_parent" android:layout_height="wrap_content"
-                android:hint="@string/search_doctor_hint"/>
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/search_doctor_hint"
+                android:textColor="@color/medical_on_surface"/>
         </com.google.android.material.textfield.TextInputLayout>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rvDoctors"
-            android:layout_width="match_parent" android:layout_height="0dp"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
             android:layout_weight="1"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,57 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/medical_background"
     android:padding="24dp">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tvTitle"
-        android:layout_width="0dp" android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:text="@string/login_title"
-        android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:textAppearance="?attr/textAppearanceDisplaySmall"
+        android:textColor="@color/medical_primary"
+        android:textStyle="bold"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/tilEmail"
-        android:layout_width="0dp" android:layout_height="wrap_content"
-        android:hint="@string/login_email"
-        app:layout_constraintTop_toBottomOf="@id/tvTitle" app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="24dp">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/etEmail"
-            android:layout_width="match_parent" android:layout_height="wrap_content"
-            android:inputType="textEmailAddress" android:hint="@string/login_hint_email"/>
-    </com.google.android.material.textfield.TextInputLayout>
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tvSubtitleLogin"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/login_subtitle"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="@color/medical_hint"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/tilPassword"
-        android:layout_width="0dp" android:layout_height="wrap_content"
-        android:hint="@string/login_password"
-        app:endIconMode="password_toggle"
-        app:layout_constraintTop_toBottomOf="@id/tilEmail" app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="12dp">
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/etPassword"
-            android:layout_width="match_parent" android:layout_height="wrap_content"
-            android:inputType="textPassword"/>
-    </com.google.android.material.textfield.TextInputLayout>
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/loginCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        app:cardBackgroundColor="@color/medical_surface"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="10dp"
+        app:layout_constraintTop_toBottomOf="@id/tvSubtitleLogin"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnLogin"
-        style="@style/Widget.Material3.Button"
-        android:layout_width="0dp" android:layout_height="wrap_content"
-        android:text="@string/action_login"
-        app:layout_constraintTop_toBottomOf="@id/tilPassword"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="20dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="24dp">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btnGoRegister"
-        style="@style/Widget.Material3.Button.OutlinedButton"
-        android:layout_width="0dp" android:layout_height="wrap_content"
-        android:text="@string/action_go_register"
-        app:layout_constraintTop_toBottomOf="@id/btnLogin"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="8dp"/>
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/login_email"
+                app:boxBackgroundMode="filled"
+                app:boxBackgroundColor="@color/medical_surface"
+                app:boxStrokeColor="@color/medical_primary"
+                app:hintTextColor="@color/medical_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etEmail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/login_hint_email"
+                    android:inputType="textEmailAddress"
+                    android:textColor="@color/medical_on_surface" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="@string/login_password"
+                app:boxBackgroundMode="filled"
+                app:boxBackgroundColor="@color/medical_surface"
+                app:boxStrokeColor="@color/medical_primary"
+                app:endIconMode="password_toggle"
+                app:hintTextColor="@color/medical_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword"
+                    android:textColor="@color/medical_on_surface" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnLogin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:backgroundTint="@color/medical_primary"
+                android:text="@string/action_login"
+                android:textColor="@color/medical_on_primary"
+                app:cornerRadius="16dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnGoRegister"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/action_go_register"
+                android:textColor="@color/medical_primary"
+                app:cornerRadius="16dp"
+                app:strokeColor="@color/medical_primary" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,85 +1,156 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/medical_background"
+    android:fillViewport="true">
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent" android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:padding="24dp">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tvTitleReg"
-            android:layout_width="0dp" android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
             android:text="@string/register_title"
-            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:textAppearance="?attr/textAppearanceDisplaySmall"
+            android:textColor="@color/medical_primary"
+            android:textStyle="bold"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilName"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:hint="@string/register_name"
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tvSubtitleReg"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/register_subtitle"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="@color/medical_hint"
             app:layout_constraintTop_toBottomOf="@id/tvTitleReg"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="24dp">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etName"
-                android:layout_width="match_parent" android:layout_height="wrap_content"/>
-        </com.google.android.material.textfield.TextInputLayout>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilEmailReg"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:hint="@string/login_email"
-            app:layout_constraintTop_toBottomOf="@id/tilName"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="12dp">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etEmailReg"
-                android:layout_width="match_parent" android:layout_height="wrap_content"
-                android:inputType="textEmailAddress"/>
-        </com.google.android.material.textfield.TextInputLayout>
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/registerCard"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="24dp"
+            app:cardBackgroundColor="@color/medical_surface"
+            app:cardCornerRadius="24dp"
+            app:cardElevation="10dp"
+            app:layout_constraintTop_toBottomOf="@id/tvSubtitleReg"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilPassReg"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:hint="@string/login_password" app:endIconMode="password_toggle"
-            app:layout_constraintTop_toBottomOf="@id/tilEmailReg"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="12dp">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etPassReg"
-                android:layout_width="match_parent" android:layout_height="wrap_content"
-                android:inputType="textPassword"/>
-        </com.google.android.material.textfield.TextInputLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilPass2Reg"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:hint="@string/register_repeat_password" app:endIconMode="password_toggle"
-            app:layout_constraintTop_toBottomOf="@id/tilPassReg"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="12dp">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etPass2Reg"
-                android:layout_width="match_parent" android:layout_height="wrap_content"
-                android:inputType="textPassword"/>
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/register_name"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="@color/medical_surface"
+                    app:boxStrokeColor="@color/medical_primary"
+                    app:hintTextColor="@color/medical_hint">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnRegister"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:text="@string/action_register"
-            app:layout_constraintTop_toBottomOf="@id/tilPass2Reg"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="20dp"/>
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etName"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/medical_on_surface" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnGoLogin"
-            style="@style/Widget.Material3.Button.OutlinedButton"
-            android:layout_width="0dp" android:layout_height="wrap_content"
-            android:text="@string/action_go_login"
-            app:layout_constraintTop_toBottomOf="@id/btnRegister"
-            app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="8dp"/>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilEmailReg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/login_email"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="@color/medical_surface"
+                    app:boxStrokeColor="@color/medical_primary"
+                    app:hintTextColor="@color/medical_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etEmailReg"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textEmailAddress"
+                        android:textColor="@color/medical_on_surface" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPassReg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/login_password"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="@color/medical_surface"
+                    app:boxStrokeColor="@color/medical_primary"
+                    app:endIconMode="password_toggle"
+                    app:hintTextColor="@color/medical_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etPassReg"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword"
+                        android:textColor="@color/medical_on_surface" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPass2Reg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:hint="@string/register_repeat_password"
+                    app:boxBackgroundMode="filled"
+                    app:boxBackgroundColor="@color/medical_surface"
+                    app:boxStrokeColor="@color/medical_primary"
+                    app:endIconMode="password_toggle"
+                    app:hintTextColor="@color/medical_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etPass2Reg"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword"
+                        android:textColor="@color/medical_on_surface" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRegister"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:backgroundTint="@color/medical_primary"
+                    android:text="@string/action_register"
+                    android:textColor="@color/medical_on_primary"
+                    app:cornerRadius="16dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnGoLogin"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/action_go_login"
+                    android:textColor="@color/medical_primary"
+                    app:cornerRadius="16dp"
+                    app:strokeColor="@color/medical_primary" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,16 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="medical_primary">#0F8B8D</color>
+    <color name="medical_on_primary">#FFFFFFFF</color>
+    <color name="medical_primary_container">#A6E3E5</color>
+    <color name="medical_on_primary_container">#023436</color>
+    <color name="medical_secondary">#4FB3BF</color>
+    <color name="medical_on_secondary">#012A2E</color>
+    <color name="medical_surface">#FFFFFFFF</color>
+    <color name="medical_on_surface">#1C1F21</color>
+    <color name="medical_background">#F2FBFB</color>
+    <color name="medical_outline">#80C7C9</color>
+    <color name="medical_hint">#557A7B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,14 +12,16 @@
     <string name="action_go_login">Ya tengo cuenta</string>
 
     <!-- Login -->
-    <string name="login_title">🔐 Inicia sesión</string>
+    <string name="login_title">Inicia sesión</string>
+    <string name="login_subtitle">Ingresa tus credenciales para continuar con tus citas.</string>
     <string name="login_email">Correo</string>
     <string name="login_password">Contraseña</string>
     <string name="login_hint_email">tucorreo@ejemplo.com</string>
     <string name="success_login">¡Hola, %1$s!</string>
 
     <!-- Registro -->
-    <string name="register_title">📝 Crear cuenta</string>
+    <string name="register_title">Crea tu cuenta</string>
+    <string name="register_subtitle">Completa tus datos para agendar y administrar tus consultas.</string>
     <string name="register_name">Nombre completo</string>
     <string name="register_repeat_password">Repite la contraseña</string>
     <string name="success_register">Cuenta creada correctamente. Ahora puedes iniciar sesión.</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,15 @@
 
     <!-- Tema de la app (Material 3, sin ActionBar porque usamos Toolbar en XML) -->
     <style name="Theme.MyApp" parent="Theme.Material3.Light.NoActionBar">
+        <item name="colorPrimary">@color/medical_primary</item>
+        <item name="colorOnPrimary">@color/medical_on_primary</item>
+        <item name="colorPrimaryContainer">@color/medical_primary_container</item>
+        <item name="colorOnPrimaryContainer">@color/medical_on_primary_container</item>
+        <item name="colorSecondary">@color/medical_secondary</item>
+        <item name="colorOnSecondary">@color/medical_on_secondary</item>
+        <item name="colorSurface">@color/medical_surface</item>
+        <item name="colorOnSurface">@color/medical_on_surface</item>
+        <item name="android:windowBackground">@color/medical_background</item>
         <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>


### PR DESCRIPTION
## Summary
- replace the hardcoded Material back icon with a local drawable to avoid unresolved references and wire it up in DoctorsActivity
- apply a cohesive medical-themed color palette across the theme, doctors list, and the authentication screens
- redesign the login and register layouts with Material cards, subtitles, and updated strings for a more professional presentation

## Testing
- ./gradlew lint *(fails: unable to download Gradle due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d60243eae8832997807a0f96cb758a