### PR TITLE
Fix toolbar back icon reference in SpecialtiesActivity

### DIFF
--- a/app/src/main/java/com/example/miscitasmedicas/SpecialtiesActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/SpecialtiesActivity.kt
@@ -18,7 +18,7 @@ class SpecialtiesActivity : AppCompatActivity() {
         setContentView(R.layout.activity_specialties)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
-        toolbar.setNavigationIcon(com.google.android.material.R.drawable.mtrl_ic_arrow_back)
+        toolbar.setNavigationIcon(R.drawable.ic_arrow_back)
         toolbar.setNavigationOnClickListener { finish() }
 
         specialties = defaultSpecialties()


### PR DESCRIPTION
## Summary
- replace the Material library back arrow reference with the app's local drawable in `SpecialtiesActivity`
- ensures the navigation icon resolves correctly when building the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6064313e083299ae189fa5a5d3875