### PR TITLE
Improve home screen palette and button labels

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent" android:layout_height="match_parent"
+    android:background="@color/medical_background"
     android:padding="24dp">
 
     <TextView
@@ -9,30 +10,43 @@
         android:layout_width="0dp" android:layout_height="wrap_content"
         android:text="@string/home_title"
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:textColor="@color/medical_on_surface"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnToSpecialties"
         android:layout_width="0dp" android:layout_height="wrap_content"
-        android:text="🗂️  @string/home_cta_specialties"
         android:layout_marginTop="24dp"
+        android:backgroundTint="@color/medical_primary"
+        android:text="@string/home_cta_specialties"
+        android:textColor="@color/medical_on_primary"
+        android:textStyle="bold"
+        app:cornerRadius="16dp"
         app:layout_constraintTop_toBottomOf="@id/tvHomeTitle"
         app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnToDoctors"
         android:layout_width="0dp" android:layout_height="wrap_content"
-        android:text="👨‍⚕️  @string/home_cta_doctors"
         android:layout_marginTop="12dp"
+        android:backgroundTint="@color/medical_primary_container"
+        android:text="@string/home_cta_doctors"
+        android:textColor="@color/medical_on_primary_container"
+        android:textStyle="bold"
+        app:cornerRadius="16dp"
         app:layout_constraintTop_toBottomOf="@id/btnToSpecialties"
         app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnNewAppointment"
         android:layout_width="0dp" android:layout_height="wrap_content"
-        android:text="@string/home_cta_new_appointment"
         android:layout_marginTop="12dp"
+        android:backgroundTint="@color/medical_secondary"
+        android:text="@string/home_cta_new_appointment"
+        android:textColor="@color/medical_on_secondary"
+        android:textStyle="bold"
+        app:cornerRadius="16dp"
         app:layout_constraintTop_toBottomOf="@id/btnToDoctors"
         app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,15 +3,15 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
-    <color name="medical_primary">#0F8B8D</color>
+    <color name="medical_primary">#1B4965</color>
     <color name="medical_on_primary">#FFFFFFFF</color>
-    <color name="medical_primary_container">#A6E3E5</color>
-    <color name="medical_on_primary_container">#023436</color>
-    <color name="medical_secondary">#4FB3BF</color>
-    <color name="medical_on_secondary">#012A2E</color>
+    <color name="medical_primary_container">#D4E4F4</color>
+    <color name="medical_on_primary_container">#0F2D40</color>
+    <color name="medical_secondary">#5FA8D3</color>
+    <color name="medical_on_secondary">#082032</color>
     <color name="medical_surface">#FFFFFFFF</color>
-    <color name="medical_on_surface">#1C1F21</color>
-    <color name="medical_background">#F2FBFB</color>
-    <color name="medical_outline">#80C7C9</color>
-    <color name="medical_hint">#557A7B</color>
+    <color name="medical_on_surface">#1E293B</color>
+    <color name="medical_background">#F3F6FB</color>
+    <color name="medical_outline">#B7C7D6</color>
+    <color name="medical_hint">#64748B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,8 @@
 
     <!-- Home -->
     <string name="home_title">🏠 Inicio</string>
-    <string name="home_cta_specialties">Ver especialidades</string>
-    <string name="home_cta_doctors">Ver doctores</string>
+    <string name="home_cta_specialties">🗂️ Ver especialidades</string>
+    <string name="home_cta_doctors">👨‍⚕️ Ver doctores</string>
     <string name="home_cta_new_appointment">➕ Nueva cita</string>
 
     <!-- Especialidades -->


### PR DESCRIPTION
## Summary
- refresh the shared medical color palette with a cooler blue scheme for a more professional feel
- refine the home screen buttons to use the new colors and properly reference localized text resources
- move the home screen emoji icons into the string resources so button labels no longer display raw "@" prefixes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d61b8d481c832997554263af4dfc45