### PR TITLE
Create fragment-driven new appointment scheduling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,10 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:theme="@style/Theme.MyApp">
 
         <activity android:name=".RegisterActivity" />
+        <activity android:name=".NewAppointmentActivity" />
         <activity android:name=".HomeActivity" />
         <activity android:name=".SpecialtiesActivity" />
         <activity android:name=".DoctorsActivity" />

--- a/app/src/main/java/com/example/miscitasmedicas/HomeActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/HomeActivity.kt
@@ -2,7 +2,6 @@ package com.example.miscitasmedicas
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.button.MaterialButton
 
@@ -21,7 +20,7 @@ class HomeActivity : AppCompatActivity() {
         }
 
         findViewById<MaterialButton>(R.id.btnNewAppointment).setOnClickListener {
-            Toast.makeText(this, R.string.placeholder_new_appointment, Toast.LENGTH_SHORT).show()
+            startActivity(Intent(this, NewAppointmentActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/example/miscitasmedicas/NewAppointmentActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/NewAppointmentActivity.kt
@@ -1,0 +1,29 @@
+package com.example.miscitasmedicas
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
+import com.example.miscitasmedicas.databinding.ActivityNewAppointmentBinding
+
+class NewAppointmentActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityNewAppointmentBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityNewAppointmentBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.new_appointment_title)
+
+        binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                replace(R.id.fragmentContainer, NewAppointmentFragment.newInstance())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/miscitasmedicas/NewAppointmentFragment.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/NewAppointmentFragment.kt
@@ -1,0 +1,242 @@
+package com.example.miscitasmedicas
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import com.example.miscitasmedicas.databinding.FragmentNewAppointmentBinding
+import com.google.android.material.datepicker.MaterialDatePicker
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+class NewAppointmentFragment : Fragment() {
+
+    private var _binding: FragmentNewAppointmentBinding? = null
+    private val binding get() = _binding!!
+    private var hostContext: Context? = null
+
+    private val calendar: Calendar = Calendar.getInstance()
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        hostContext = context
+        logLifecycle("onAttach")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        logLifecycle("onCreate")
+        setHasOptionsMenu(false)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        logLifecycle("onCreateView")
+        _binding = FragmentNewAppointmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        logLifecycle("onViewCreated")
+        setupUi()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        logLifecycle("onStart")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        logLifecycle("onResume")
+    }
+
+    override fun onPause() {
+        logLifecycle("onPause")
+        super.onPause()
+    }
+
+    override fun onStop() {
+        logLifecycle("onStop")
+        super.onStop()
+    }
+
+    override fun onDestroyView() {
+        logLifecycle("onDestroyView")
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onDestroy() {
+        logLifecycle("onDestroy")
+        super.onDestroy()
+    }
+
+    override fun onDetach() {
+        logLifecycle("onDetach")
+        hostContext = null
+        super.onDetach()
+    }
+
+    private fun setupUi() {
+        val specialties = resources.getStringArray(R.array.new_appointment_specialties)
+        val adapter = ArrayAdapter(
+            hostContext ?: requireContext(),
+            android.R.layout.simple_list_item_1,
+            specialties
+        )
+        binding.inputSpecialty.setAdapter(adapter)
+        binding.inputSpecialty.setOnItemClickListener { _, _, _, _ ->
+            binding.textFieldSpecialty.error = null
+        }
+
+        binding.inputAppointmentDate.setOnClickListener { showDatePicker() }
+        binding.inputAppointmentDate.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) showDatePicker()
+        }
+
+        binding.inputAppointmentTime.setOnClickListener { showTimePicker() }
+        binding.inputAppointmentTime.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) showTimePicker()
+        }
+
+        binding.btnSchedule.setOnClickListener { validateAndSchedule() }
+    }
+
+    private fun showDatePicker() {
+        val picker = MaterialDatePicker.Builder.datePicker()
+            .setTitleText(getString(R.string.new_appointment_date_picker_title))
+            .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
+            .build()
+
+        picker.addOnPositiveButtonClickListener { selection ->
+            val utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+            utcCalendar.timeInMillis = selection
+
+            calendar.set(Calendar.YEAR, utcCalendar.get(Calendar.YEAR))
+            calendar.set(Calendar.MONTH, utcCalendar.get(Calendar.MONTH))
+            calendar.set(Calendar.DAY_OF_MONTH, utcCalendar.get(Calendar.DAY_OF_MONTH))
+
+            val formatter = SimpleDateFormat("dd 'de' MMMM yyyy", Locale.getDefault())
+            binding.inputAppointmentDate.setText(formatter.format(calendar.time))
+            binding.textFieldAppointmentDate.error = null
+        }
+
+        picker.show(parentFragmentManager, DATE_PICKER_TAG)
+    }
+
+    private fun showTimePicker() {
+        val picker = MaterialTimePicker.Builder()
+            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setHour(calendar.get(Calendar.HOUR_OF_DAY))
+            .setMinute(calendar.get(Calendar.MINUTE))
+            .setTitleText(getString(R.string.new_appointment_time_picker_title))
+            .build()
+
+        picker.addOnPositiveButtonClickListener {
+            calendar.set(Calendar.HOUR_OF_DAY, picker.hour)
+            calendar.set(Calendar.MINUTE, picker.minute)
+
+            val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
+            binding.inputAppointmentTime.setText(formatter.format(calendar.time))
+            binding.textFieldAppointmentTime.error = null
+        }
+
+        picker.show(parentFragmentManager, TIME_PICKER_TAG)
+    }
+
+    private fun validateAndSchedule() {
+        val name = binding.inputPatientName.text?.toString().orEmpty().trim()
+        val specialty = binding.inputSpecialty.text?.toString().orEmpty().trim()
+        val date = binding.inputAppointmentDate.text?.toString().orEmpty().trim()
+        val time = binding.inputAppointmentTime.text?.toString().orEmpty().trim()
+        val notes = binding.inputNotes.text?.toString().orEmpty().trim()
+
+        binding.textFieldPatientName.error = if (name.isEmpty()) {
+            getString(R.string.error_name_required)
+        } else {
+            null
+        }
+
+        binding.textFieldSpecialty.error = if (specialty.isEmpty()) {
+            getString(R.string.new_appointment_error_specialty)
+        } else {
+            null
+        }
+
+        binding.textFieldAppointmentDate.error = if (date.isEmpty()) {
+            getString(R.string.new_appointment_error_date)
+        } else {
+            null
+        }
+
+        binding.textFieldAppointmentTime.error = if (time.isEmpty()) {
+            getString(R.string.new_appointment_error_time)
+        } else {
+            null
+        }
+
+        val hasError = listOf(
+            binding.textFieldPatientName.error,
+            binding.textFieldSpecialty.error,
+            binding.textFieldAppointmentDate.error,
+            binding.textFieldAppointmentTime.error
+        ).any { it != null }
+
+        if (hasError) {
+            Toast.makeText(
+                hostContext ?: requireContext(),
+                getString(R.string.new_appointment_error_form),
+                Toast.LENGTH_SHORT
+            ).show()
+            return
+        }
+
+        val summary = getString(
+            R.string.new_appointment_confirmation,
+            name,
+            specialty,
+            date,
+            time,
+            if (notes.isEmpty()) getString(R.string.new_appointment_no_notes) else notes
+        )
+
+        binding.cardConfirmation.visibility = View.VISIBLE
+        binding.tvConfirmation.text = summary
+        binding.cardConfirmation.setCardBackgroundColor(
+            ContextCompat.getColor(requireContext(), R.color.medical_primary_container)
+        )
+
+        Toast.makeText(
+            hostContext ?: requireContext(),
+            getString(R.string.new_appointment_success_toast),
+            Toast.LENGTH_LONG
+        ).show()
+    }
+
+    private fun logLifecycle(event: String) {
+        Log.d(TAG, "🔁 $event — Fragment de nueva cita activo")
+    }
+
+    companion object {
+        private const val TAG = "NewAppointmentFragment"
+        private const val DATE_PICKER_TAG = "NewAppointmentDatePicker"
+        private const val TIME_PICKER_TAG = "NewAppointmentTimePicker"
+
+        fun newInstance(): NewAppointmentFragment = NewAppointmentFragment()
+    }
+}

--- a/app/src/main/res/drawable/ic_event.xml
+++ b/app/src/main/res/drawable/ic_event.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/medical_hint">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,12h-5v5h5v-5zM16,1v2H8V1H6v2H5c-1.11,0 -1.99,0.9 -1.99,2L3,19c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2h-1V1h-2zm3,18H5V8h14v11z" />
+</vector>

--- a/app/src/main/res/drawable/ic_schedule.xml
+++ b/app/src/main/res/drawable/ic_schedule.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/medical_hint">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,8c-0.55,0 -1,0.45 -1,1v4c0,0.26 0.11,0.52 0.29,0.71l2.5,2.5c0.39,0.39 1.03,0.39 1.41,0 0.39,-0.39 0.39,-1.03 0,-1.41L13,12.59V9c0,-0.55 -0.45,-1 -1,-1zm0,-6C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zm0,18c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+</vector>

--- a/app/src/main/res/layout/activity_new_appointment.xml
+++ b/app/src/main/res/layout/activity_new_appointment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/medical_background">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/medical_surface">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="@style/Widget.MyApp.Toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/ThemeOverlay.Material3.ActionBar"
+            app:navigationIcon="@drawable/ic_arrow_back" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_new_appointment.xml
+++ b/app/src/main/res/layout/fragment_new_appointment.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:padding="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:id="@+id/tvSubtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/new_appointment_subtitle"
+            android:textColor="@color/medical_on_surface"
+            android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textFieldPatientName"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:hint="@string/new_appointment_patient_name"
+            app:boxStrokeColor="@color/medical_outline"
+            app:hintTextColor="@color/medical_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputPatientName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="textPersonName" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textFieldSpecialty"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/new_appointment_specialty"
+            app:boxStrokeColor="@color/medical_outline"
+            app:hintTextColor="@color/medical_hint"
+            app:endIconMode="dropdown">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/inputSpecialty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="text" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textFieldAppointmentDate"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/new_appointment_date"
+            app:boxStrokeColor="@color/medical_outline"
+            app:hintTextColor="@color/medical_hint"
+            app:startIconDrawable="@drawable/ic_event">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputAppointmentDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="false"
+                android:inputType="none"
+                android:clickable="true"
+                android:importantForAutofill="no"
+                android:imeOptions="actionNext" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textFieldAppointmentTime"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/new_appointment_time"
+            app:boxStrokeColor="@color/medical_outline"
+            app:hintTextColor="@color/medical_hint"
+            app:startIconDrawable="@drawable/ic_schedule">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputAppointmentTime"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="false"
+                android:inputType="none"
+                android:clickable="true"
+                android:importantForAutofill="no"
+                android:imeOptions="actionNext" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textFieldNotes"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:hint="@string/new_appointment_notes"
+            app:boxStrokeColor="@color/medical_outline"
+            app:hintTextColor="@color/medical_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputNotes"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:inputType="textMultiLine"
+                android:maxLines="4" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnSchedule"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:backgroundTint="@color/medical_secondary"
+            android:text="@string/new_appointment_action"
+            android:textColor="@color/medical_on_secondary"
+            android:textStyle="bold"
+            app:cornerRadius="16dp" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardConfirmation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:visibility="gone"
+            app:cardCornerRadius="20dp"
+            app:cardElevation="0dp">
+
+            <TextView
+                android:id="@+id/tvConfirmation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="20dp"
+                android:textColor="@color/medical_on_primary_container"
+                android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="new_appointment_specialties">
+        <item>Medicina general</item>
+        <item>Pediatría</item>
+        <item>Cardiología</item>
+        <item>Dermatología</item>
+        <item>Odontología</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,25 @@
     <string name="home_cta_doctors">👨‍⚕️ Ver doctores</string>
     <string name="home_cta_new_appointment">➕ Nueva cita</string>
 
+    <!-- Nueva cita -->
+    <string name="new_appointment_title">🗓️ Nueva cita</string>
+    <string name="new_appointment_subtitle">Organiza tu próxima consulta paso a paso.</string>
+    <string name="new_appointment_patient_name">👤 Nombre del paciente</string>
+    <string name="new_appointment_specialty">🩺 Especialidad</string>
+    <string name="new_appointment_date">📅 Fecha</string>
+    <string name="new_appointment_time">⏰ Hora</string>
+    <string name="new_appointment_notes">📝 Notas (opcional)</string>
+    <string name="new_appointment_action">Agendar cita ✨</string>
+    <string name="new_appointment_date_picker_title">Elige la fecha</string>
+    <string name="new_appointment_time_picker_title">Elige la hora</string>
+    <string name="new_appointment_error_specialty">Selecciona una especialidad.</string>
+    <string name="new_appointment_error_date">Selecciona una fecha.</string>
+    <string name="new_appointment_error_time">Selecciona una hora.</string>
+    <string name="new_appointment_error_form">Completa los campos obligatorios para continuar.</string>
+    <string name="new_appointment_confirmation">🎉 ¡Cita lista!&#x0A;Paciente: %1$s&#x0A;Especialidad: %2$s&#x0A;Fecha: %3$s&#x0A;Hora: %4$s&#x0A;Notas: %5$s</string>
+    <string name="new_appointment_no_notes">Sin notas adicionales.</string>
+    <string name="new_appointment_success_toast">✨ Cita creada con éxito. ¡Nos vemos pronto!</string>
+
     <!-- Especialidades -->
     <string name="specialties_title">🗂️ Especialidades</string>
     <string name="specialties_search_hint">Buscar especialidad…</string>


### PR DESCRIPTION
## Summary
- add a dedicated NewAppointmentActivity that hosts the scheduling fragment with toolbar navigation
- implement NewAppointmentFragment with lifecycle logging, context usage, validation, and Material pickers to create appointments with emojis
- enable view binding and wire the home shortcut plus resources for the new appointment flow

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df4c5fff788320b59a065c9b201a9c