### PR TITLE
Fix dropdown end icon mode in new appointment fragment

### DIFF
--- a/app/src/main/res/layout/fragment_new_appointment.xml
+++ b/app/src/main/res/layout/fragment_new_appointment.xml
@@ -48,7 +48,7 @@
             android:hint="@string/new_appointment_specialty"
             app:boxStrokeColor="@color/medical_outline"
             app:hintTextColor="@color/medical_hint"
-            app:endIconMode="dropdown">
+            app:endIconMode="dropdown_menu">
 
             <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/inputSpecialty"


### PR DESCRIPTION
## Summary
- update the new appointment specialty field to use the correct `dropdown_menu` end icon mode

## Testing
- `./gradlew :app:processDebugResources` *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_b_68df4ef3b36883208e362fc1d1fcef71