### PR TITLE
Add saved appointments section and persistence

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:theme="@style/Theme.MyApp">
 
         <activity android:name=".RegisterActivity" />
+        <activity android:name=".AppointmentsActivity" />
         <activity android:name=".NewAppointmentActivity" />
         <activity android:name=".HomeActivity" />
         <activity android:name=".SpecialtiesActivity" />

--- a/app/src/main/java/com/example/miscitasmedicas/Appointment.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/Appointment.kt
@@ -1,0 +1,49 @@
+package com.example.miscitasmedicas
+
+import org.json.JSONObject
+
+private const val KEY_PATIENT_NAME = "patient_name"
+private const val KEY_SPECIALTY = "specialty"
+private const val KEY_DATE = "date"
+private const val KEY_TIME = "time"
+private const val KEY_NOTES = "notes"
+
+/**
+ * Representa una cita médica agendada por el usuario.
+ */
+data class Appointment(
+    val patientName: String,
+    val specialty: String,
+    val date: String,
+    val time: String,
+    val notes: String
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        put(KEY_PATIENT_NAME, patientName)
+        put(KEY_SPECIALTY, specialty)
+        put(KEY_DATE, date)
+        put(KEY_TIME, time)
+        put(KEY_NOTES, notes)
+    }
+
+    companion object {
+        fun fromJson(json: JSONObject?): Appointment? {
+            if (json == null) return null
+            val patientName = json.optString(KEY_PATIENT_NAME)
+            val specialty = json.optString(KEY_SPECIALTY)
+            val date = json.optString(KEY_DATE)
+            val time = json.optString(KEY_TIME)
+            if (patientName.isNullOrBlank() || specialty.isNullOrBlank() || date.isNullOrBlank() || time.isNullOrBlank()) {
+                return null
+            }
+            val notes = json.optString(KEY_NOTES)
+            return Appointment(
+                patientName = patientName,
+                specialty = specialty,
+                date = date,
+                time = time,
+                notes = notes
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/miscitasmedicas/AppointmentStorage.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/AppointmentStorage.kt
@@ -1,0 +1,46 @@
+package com.example.miscitasmedicas
+
+import android.content.Context
+import org.json.JSONArray
+
+private const val PREFS_APPOINTMENTS = "appointments_storage"
+private const val KEY_APPOINTMENTS = "appointments"
+
+/**
+ * Maneja el almacenamiento simple de citas usando SharedPreferences.
+ */
+class AppointmentStorage(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREFS_APPOINTMENTS, Context.MODE_PRIVATE)
+
+    fun saveAppointment(appointment: Appointment) {
+        val current = getAppointments().toMutableList()
+        current.add(0, appointment)
+
+        val array = JSONArray()
+        current.forEach { array.put(it.toJson()) }
+
+        prefs.edit().putString(KEY_APPOINTMENTS, array.toString()).apply()
+    }
+
+    fun getAppointments(): List<Appointment> {
+        val stored = prefs.getString(KEY_APPOINTMENTS, null) ?: return emptyList()
+        return try {
+            val array = JSONArray(stored)
+            buildList {
+                for (i in 0 until array.length()) {
+                    val appointment = Appointment.fromJson(array.optJSONObject(i))
+                    if (appointment != null) {
+                        add(appointment)
+                    }
+                }
+            }
+        } catch (exception: Exception) {
+            emptyList()
+        }
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_APPOINTMENTS).apply()
+    }
+}

--- a/app/src/main/java/com/example/miscitasmedicas/AppointmentsActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/AppointmentsActivity.kt
@@ -1,0 +1,74 @@
+package com.example.miscitasmedicas
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.example.miscitasmedicas.databinding.ActivityAppointmentsBinding
+import com.example.miscitasmedicas.databinding.ItemAppointmentBinding
+
+class AppointmentsActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAppointmentsBinding
+    private lateinit var storage: AppointmentStorage
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAppointmentsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.appointments_title)
+        binding.toolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
+
+        storage = AppointmentStorage(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        renderAppointments()
+    }
+
+    private fun renderAppointments() {
+        val appointments = storage.getAppointments()
+        binding.listAppointments.removeAllViews()
+
+        if (appointments.isEmpty()) {
+            binding.emptyState.visibility = View.VISIBLE
+            binding.scrollContent.visibility = View.GONE
+            return
+        }
+
+        binding.emptyState.visibility = View.GONE
+        binding.scrollContent.visibility = View.VISIBLE
+
+        val inflater = LayoutInflater.from(this)
+        appointments.forEach { appointment ->
+            val itemBinding = ItemAppointmentBinding.inflate(inflater, binding.listAppointments, false)
+            itemBinding.tvPatientName.text = getString(
+                R.string.appointments_patient_name,
+                appointment.patientName
+            )
+            itemBinding.tvSpecialty.text = getString(
+                R.string.appointments_specialty,
+                appointment.specialty
+            )
+            itemBinding.tvDateTime.text = getString(
+                R.string.appointments_date_time,
+                appointment.date,
+                appointment.time
+            )
+            val notesText = if (appointment.notes.isBlank()) {
+                getString(R.string.appointments_notes_empty)
+            } else {
+                getString(R.string.appointments_notes, appointment.notes)
+            }
+            itemBinding.tvNotes.text = notesText
+
+            binding.listAppointments.addView(itemBinding.root)
+        }
+    }
+}

--- a/app/src/main/java/com/example/miscitasmedicas/HomeActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/HomeActivity.kt
@@ -22,5 +22,9 @@ class HomeActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.btnNewAppointment).setOnClickListener {
             startActivity(Intent(this, NewAppointmentActivity::class.java))
         }
+
+        findViewById<MaterialButton>(R.id.btnAppointments).setOnClickListener {
+            startActivity(Intent(this, AppointmentsActivity::class.java))
+        }
     }
 }

--- a/app/src/main/java/com/example/miscitasmedicas/NewAppointmentFragment.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/NewAppointmentFragment.kt
@@ -26,6 +26,9 @@ class NewAppointmentFragment : Fragment() {
     private var hostContext: Context? = null
 
     private val calendar: Calendar = Calendar.getInstance()
+    private val appointmentStorage: AppointmentStorage by lazy(LazyThreadSafetyMode.NONE) {
+        AppointmentStorage(requireContext().applicationContext)
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -213,6 +216,16 @@ class NewAppointmentFragment : Fragment() {
             date,
             time,
             if (notes.isEmpty()) getString(R.string.new_appointment_no_notes) else notes
+        )
+
+        appointmentStorage.saveAppointment(
+            Appointment(
+                patientName = name,
+                specialty = specialty,
+                date = date,
+                time = time,
+                notes = notes
+            )
         )
 
         binding.cardConfirmation.visibility = View.VISIBLE

--- a/app/src/main/res/drawable/divider_transparent_16dp.xml
+++ b/app/src/main/res/drawable/divider_transparent_16dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size android:height="16dp" />
+    <solid android:color="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/layout/activity_appointments.xml
+++ b/app/src/main/res/layout/activity_appointments.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/medical_background">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/medical_background"
+        android:navigationIconTint="@color/medical_on_surface"
+        app:titleTextColor="@color/medical_on_surface" />
+
+    <LinearLayout
+        android:id="@+id/emptyState"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingHorizontal="32dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/appointments_empty_title"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="@color/medical_on_surface" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:text="@string/appointments_empty_subtitle"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="@color/medical_on_surface_variant" />
+    </LinearLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollContent"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:padding="24dp">
+
+        <LinearLayout
+            android:id="@+id/listAppointments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:showDividers="middle"
+            android:divider="@drawable/divider_transparent_16dp" />
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -49,4 +49,18 @@
         app:cornerRadius="16dp"
         app:layout_constraintTop_toBottomOf="@id/btnToDoctors"
         app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnAppointments"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:backgroundTint="@color/medical_primary_container"
+        android:text="@string/home_cta_appointments"
+        android:textColor="@color/medical_on_primary_container"
+        android:textStyle="bold"
+        app:cornerRadius="16dp"
+        app:layout_constraintTop_toBottomOf="@id/btnNewAppointment"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_appointment.xml
+++ b/app/src/main/res/layout/item_appointment.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:backgroundTint="@color/medical_surface"
+    app:cardCornerRadius="20dp"
+    app:cardElevation="0dp"
+    app:strokeColor="@color/medical_primary"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/tvPatientName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/medical_on_surface"
+            android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+        <TextView
+            android:id="@+id/tvSpecialty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/medical_on_surface_variant"
+            android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+        <TextView
+            android:id="@+id/tvDateTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textColor="@color/medical_on_surface"
+            android:textAppearance="?attr/textAppearanceBodyLarge" />
+
+        <TextView
+            android:id="@+id/tvNotes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/medical_on_surface_variant"
+            android:textAppearance="?attr/textAppearanceBodyMedium" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,7 @@
     <color name="medical_on_secondary">#082032</color>
     <color name="medical_surface">#FFFFFFFF</color>
     <color name="medical_on_surface">#1E293B</color>
+    <color name="medical_on_surface_variant">#475569</color>
     <color name="medical_background">#F3F6FB</color>
     <color name="medical_outline">#B7C7D6</color>
     <color name="medical_hint">#64748B</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="home_cta_specialties">🗂️ Ver especialidades</string>
     <string name="home_cta_doctors">👨‍⚕️ Ver doctores</string>
     <string name="home_cta_new_appointment">➕ Nueva cita</string>
+    <string name="home_cta_appointments">📘 Mis citas guardadas</string>
 
     <!-- Nueva cita -->
     <string name="new_appointment_title">🗓️ Nueva cita</string>
@@ -62,7 +63,17 @@
     <string name="new_appointment_error_form">Completa los campos obligatorios para continuar.</string>
     <string name="new_appointment_confirmation">🎉 ¡Cita lista!&#x0A;Paciente: %1$s&#x0A;Especialidad: %2$s&#x0A;Fecha: %3$s&#x0A;Hora: %4$s&#x0A;Notas: %5$s</string>
     <string name="new_appointment_no_notes">Sin notas adicionales.</string>
-    <string name="new_appointment_success_toast">✨ Cita creada con éxito. ¡Nos vemos pronto!</string>
+    <string name="new_appointment_success_toast">✨ Cita creada y guardada con éxito. ¡Nos vemos pronto!</string>
+
+    <!-- Citas guardadas -->
+    <string name="appointments_title">📘 Mis citas</string>
+    <string name="appointments_empty_title">Aún no tienes citas guardadas.</string>
+    <string name="appointments_empty_subtitle">Agenda una nueva cita y aparecerá en esta lista automáticamente.</string>
+    <string name="appointments_patient_name">👤 Paciente: %1$s</string>
+    <string name="appointments_specialty">🩺 Especialidad: %1$s</string>
+    <string name="appointments_date_time">📅 %1$s • ⏰ %2$s</string>
+    <string name="appointments_notes">📝 Notas: %1$s</string>
+    <string name="appointments_notes_empty">📝 Sin notas adicionales.</string>
 
     <!-- Especialidades -->
     <string name="specialties_title">🗂️ Especialidades</string>


### PR DESCRIPTION
## Summary
- persist scheduled appointments using a new Appointment model and shared preferences helper
- add an appointments screen with card-based summaries and link it from the home screen

## Testing
- `./gradlew lint` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68df543904408320a2b65bfd5926a2a2