### PR TITLE
Add accessibility description to appointments screen

### DIFF
--- a/app/src/main/res/layout/activity_appointments.xml
+++ b/app/src/main/res/layout/activity_appointments.xml
@@ -46,6 +46,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
+        android:contentDescription="@string/appointments_list_content_description"
         android:padding="24dp">
 
         <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="appointments_title">📘 Mis citas</string>
     <string name="appointments_empty_title">Aún no tienes citas guardadas.</string>
     <string name="appointments_empty_subtitle">Agenda una nueva cita y aparecerá en esta lista automáticamente.</string>
+    <string name="appointments_list_content_description">Lista de citas médicas programadas.</string>
     <string name="appointments_patient_name">👤 Paciente: %1$s</string>
     <string name="appointments_specialty">🩺 Especialidad: %1$s</string>
     <string name="appointments_date_time">📅 %1$s • ⏰ %2$s</string>


### PR DESCRIPTION
## Summary
- describe the appointments scrollable list for accessibility services
- add a localized string resource for the new description

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df560fb8348320ae386f3032ff3721