### PR TITLE
Fix MaterialToolbar navigation icon tint attribute

### DIFF
--- a/app/src/main/res/layout/activity_appointments.xml
+++ b/app/src/main/res/layout/activity_appointments.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/medical_background"
-        android:navigationIconTint="@color/medical_on_surface"
+        app:navigationIconTint="@color/medical_on_surface"
         app:titleTextColor="@color/medical_on_surface" />
 
     <LinearLayout


### PR DESCRIPTION
## Summary
- replace the unsupported `android:navigationIconTint` with the Material Components `app:navigationIconTint` attribute on the appointments toolbar

## Testing
- ./gradlew :app:processDebugResources *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df56ff4e4883209f14f3511925f5b7