### PR TITLE
Fix appointment list formatting strings

### DIFF
--- a/app/src/main/java/com/example/miscitasmedicas/AppointmentsActivity.kt
+++ b/app/src/main/java/com/example/miscitasmedicas/AppointmentsActivity.kt
@@ -62,23 +62,24 @@ class AppointmentsActivity : AppCompatActivity() {
             val tvDateTime = itemView.findViewById<TextView>(R.id.tvDateTime)
             val tvNotes = itemView.findViewById<TextView>(R.id.tvNotes)
 
-            tvPatientName.text = getString(
-                R.string.appointments_patient_name,
-                appointment.patientName
-            )
-            tvSpecialty.text = getString(
-                R.string.appointments_specialty,
-                appointment.specialty
-            )
-            tvDateTime.text = getString(
-                R.string.appointments_date_time,
-                appointment.date,
-                appointment.time
-            )
+            tvPatientName.text = getString(R.string.appointments_patient_name) +
+                " " + appointment.patientName
+            tvSpecialty.text = getString(R.string.appointments_specialty) +
+                " " + appointment.specialty
+            val dateTimeText = buildString {
+                append(getString(R.string.appointments_date))
+                append(' ')
+                append(appointment.date)
+                append(" • ")
+                append(getString(R.string.appointments_time))
+                append(' ')
+                append(appointment.time)
+            }
+            tvDateTime.text = dateTimeText
             val notesText = if (appointment.notes.isBlank()) {
                 getString(R.string.appointments_notes_empty)
             } else {
-                getString(R.string.appointments_notes, appointment.notes)
+                getString(R.string.appointments_notes) + " " + appointment.notes
             }
             tvNotes.text = notesText
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,10 +70,11 @@
     <string name="appointments_empty_title">Aún no tienes citas guardadas.</string>
     <string name="appointments_empty_subtitle">Agenda una nueva cita y aparecerá en esta lista automáticamente.</string>
     <string name="appointments_list_content_description">Lista de citas médicas programadas.</string>
-    <string name="appointments_patient_name">👤 Paciente: %1$s</string>
-    <string name="appointments_specialty">🩺 Especialidad: %1$s</string>
-    <string name="appointments_date_time">📅 %1$s • ⏰ %2$s</string>
-    <string name="appointments_notes">📝 Notas: %1$s</string>
+    <string name="appointments_patient_name">👤 Paciente:</string>
+    <string name="appointments_specialty">🩺 Especialidad:</string>
+    <string name="appointments_date">📅</string>
+    <string name="appointments_time">⏰</string>
+    <string name="appointments_notes">📝 Notas:</string>
     <string name="appointments_notes_empty">📝 Sin notas adicionales.</string>
 
     <!-- Especialidades -->


### PR DESCRIPTION
## Summary
- avoid passing formatting arguments to appointment strings by concatenating labels and values in code
- split appointment resource strings into label-only values for patient, specialty, date, time, and notes

## Testing
- not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68df5e5b72148320bc13470847a05239